### PR TITLE
fixed Bot.create() and Bot.post()

### DIFF
--- a/groupy/api/endpoint.py
+++ b/groupy/api/endpoint.py
@@ -8,7 +8,6 @@ from PIL import Image as PImage
 import time
 import json
 
-
 class Endpoint:
     '''An API endpoint capable of building a url and extracting data from the
     response.
@@ -445,12 +444,15 @@ class Bots(Endpoint):
         """
         r = requests.post(
             cls.build_url(),
-            params={
-                'name': name,
-                'group_id': group_id,
-                'avatar_url': avatar_url,
-                'callback_url': callback_url
-            }
+            data=json.dumps({
+                "bot": {
+                    'name': name,
+                    'group_id': group_id,
+                    'avatar_url': avatar_url,
+                    'callback_url': callback_url
+                }
+            }),
+            headers={'content-type': 'application/json'}
         )
         return cls.response(r)
 
@@ -466,11 +468,12 @@ class Bots(Endpoint):
         """
         r = requests.post(
             cls.build_url('post'),
-            params={
+            data=json.dumps({
                 'bot_id': bot_id,
                 'text': text,
                 'picture_url': picture_url
-            }
+            }),
+            headers={'content-type': 'application/json'}
         )
         return cls.response(r)
 

--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -583,7 +583,7 @@ class Bot(ApiResponse):
         """
         bot = endpoint.Bots.create(name, group.group_id,
                                    avatar_url, callback_url)
-        return cls(**bot)
+        return cls(**bot['bot'])
 
     @classmethod
     def list(cls):


### PR DESCRIPTION
Parameters for bot creation and posting messages from a bot were being passed as URL parameters and not as the POST body.

Even though [GroupMe's API docs for bot creation](https://dev.groupme.com/docs/v3#bots_create) suggest that the data should be passed as URL parameters, this actually doesn't work. You need to pass them in the body of the POST as JSON, as is described [here](https://dev.groupme.com/tutorials/bots).
Posting messages works the same way; data must be sent as a JSON block in the POST body and not as URL parameters.
There was a companion error to this one in the Bot class initializer. The dictionary returned by the API encapsulates the expected data within an entry with key 'bot', but the full dictionary is returned.

Each of these issues has been fixed; the diff is self-explanatory.