### PR TITLE
Add group_id to update() call in Group.update().

### DIFF
--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -247,7 +247,8 @@ class Group(Recipient):
         :param str image_url: the URL for the new group image
         :param bool share: whether to generate a share URL
         """
-        endpoint.Groups.update(name=name, description=description,
+        endpoint.Groups.update(self.group_id,
+                               name=name, description=description,
                                image_url=image_url, share=share)
         self.refresh()
 


### PR DESCRIPTION
`endpoint.Groups.update()` takes a group ID as its first parameter,
but this parameter was (previously) not provided to that function by
`object.responses.Group.update()`; the result was that `Group.update()` would never perform any useful work but instead always cause a `TypeError`. The bug is fixed by placing `self.group_id` as the first parameter of this call inside `Group.update()`.