### PR TITLE
Fix Member.identification().

### DIFF
--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -386,7 +386,7 @@ class Member(Recipient):
         return {
             'nickname': self.nickname,
             'user_id': self.user_id,
-            'guid': self._guid         # new guid set if nonexistant
+            'guid': self.guid         # new guid set if nonexistant
         }
 
     @classmethod


### PR DESCRIPTION
It now uses `self.guid`, the property which refreshes `self._guid`,
instead of `self._guid` itself. The comment and documentation
are thus now correct.

(Previous incorrect behavior was to always set the `guid` key to
`None` if no GUID was provided by the library-user.)