### PR TITLE
Add attachments support to Bot.post

### DIFF
--- a/groupy/api/endpoint.py
+++ b/groupy/api/endpoint.py
@@ -469,12 +469,13 @@ class Bots(Endpoint):
         return cls.response(r)
 
     @classmethod
-    def post(cls, bot_id, text, picture_url=None):
+    def post(cls, bot_id, text, *attachments, picture_url=None):
         """Post a message to a group as a bot.
 
         :param str bot_id: the ID of the bot
         :param str text: the message text
         :param str picture_url: the GroupMe image URL for a picture
+        :param list attachments: a list of attachments to include
         :returns: the created message
         :rtype: :class:`dict`
         """
@@ -483,7 +484,8 @@ class Bots(Endpoint):
             data=json.dumps({
                 'bot_id': bot_id,
                 'text': text,
-                'picture_url': picture_url
+                'picture_url': picture_url,
+                'attachments': attachments
             }),
             headers={'content-type': 'application/json'}
         )

--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -602,17 +602,18 @@ class Bot(ApiResponse):
         """
         return FilterList(Bot(**b) for b in endpoint.Bots.index())
 
-    def post(self, text, picture_url=None):
+    def post(self, text, *attachments, picture_url=None):
         """Post a message to the group of the bot.
 
         :param str text: the message text
         :param str picture_url: the GroupMe image URL for an image
+        :param list attachments: the attachments to include
         :returns: ``True`` if successful
         :rtype: bool
         :raises groupy.api.errors.ApiError: if unsuccessful
         """
         try:
-            endpoint.Bots.post(self.bot_id, text, picture_url)
+            endpoint.Bots.post(self.bot_id, text, *attachments, picture_url=picture_url)
         except errors.ApiError as e:
             if e.args[0].status_code >= status.BAD_REQUEST:
                 raise


### PR DESCRIPTION
This feature is not documented by GroupMe, but it has been observed previously by [others] and recently by myself. All attachment types supported in non-bot posts seem to be supported in bot posts. (&hellip;possibly excluding the undocumented Events attachment, which I didn't investigate and which is probably of little use anyway since it consists entirely of pointers into the auxiliary API at `https://api.groupme.com/v3/conversations/{group_id}/events/{create,show,list,update,rsvp,delete}`.)

[others]: https://groups.google.com/d/msg/groupme-api-support/mNyIZB_S1jc/jxsvNigwX9MJ