### PR TITLE
Set responses.Message._user as needed

### DIFF
--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -538,6 +538,8 @@ class Message(ApiResponse):
 
         :rtype: bool
         """
+        if self._user is None:
+            self._user = User.get()
         return self.user_id == self._user.user_id
 
     def is_liked_by_me(self):
@@ -545,6 +547,8 @@ class Message(ApiResponse):
 
         :rtype: bool
         """
+        if self._user is None:
+            self._user = User.get()
         return self._user.user_id in self.favorited_by
 
     def metions_me(self):
@@ -552,6 +556,8 @@ class Message(ApiResponse):
 
         :rtype: bool
         """
+        if self._user is None:
+            self._user = User.get()
         for a in self.attachments:
             if a.type == 'mentions' and self._user.user_id in a.user_ids:
                 return True


### PR DESCRIPTION
Previously, `is_liked_by_me`, `is_from_me` and `metions_me` would always raise exceptions if called on a Message which wasn't a direct message.

Now, these methods, like the Direct Message branch of the constructor's `conversation_id` calculation, initialize `self._user` if it `is None`.

(Alternative approach would have been to insert an unconditional `self._user = User.get()` near the start of the constructor, but I believe that would cause many spurious HTTP requests.)

(Other alternative approach would be to make some kind of lazy-evaluation wrapper for `self._user` or in `User` itself. While lazy evaluation is probably generally useful for network-backed object models, it's probably overkill to use it merely here.)