### PR TITLE
Adding support for Gallery endpoint 

### DIFF
--- a/groupy/object/listers.py
+++ b/groupy/object/listers.py
@@ -9,6 +9,7 @@ This module contains classes that provide filterable lists and message pagers.
 
 """
 import operator
+from datetime import datetime
 
 from ..api import errors
 
@@ -173,3 +174,30 @@ class MessagePager(FilterList):
         else:
             self.extend(self.older())
         return True
+
+class GalleryPager(MessagePager):
+    """A filterable, extendable page of messages in the Gallery.
+
+    :param group: the group from which to page through messages
+    :type group: :class:`~groupy.object.responses.Group`
+    :param list messages: the initial page of messages
+    :param bool backward: whether the oldest message is at index 0
+    """
+    def __init__(self, group, messages, backward=False):
+        super().__init__(group, messages, backward)
+
+    def newer(self):
+        """Return the next (newer) page of messages.
+
+        :returns: a newer page of messages
+        :rtype: :class:`~groupy.object.listers.MessagePager`
+        """
+        return self.group.gallery(after=datetime.utcfromtimestamp(int(self.oldest.created_at.timestamp())))
+
+    def older(self):
+        """Return the previous (older) page of messages.
+
+        :returns: an older page of messages
+        :rtype: :class:`~groupy.object.listers.MessagePager`
+        """
+        return self.group.gallery(before=datetime.utcfromtimestamp(int(self.oldest.created_at.timestamp())))

--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -19,7 +19,7 @@ from .. import config
 from ..api import status
 from ..api import errors
 from ..api import endpoint
-from .listers import FilterList, MessagePager
+from .listers import FilterList, MessagePager, GalleryPager
 from .attachments import AttachmentFactory
 
 
@@ -140,6 +140,52 @@ class Recipient(ApiResponse):
         self.message_count = r['count']
         messages = (Message(self, **m) for m in r[self._mkey])
         return MessagePager(self, messages, backward=backward)
+
+    def gallery(self, before=None, since=None, after=None, limit=None):
+        """Return a page of messages from the gallery of the recipient.
+
+        .. note::
+
+            Only one of ``before``, ``after``, or ``since`` can be specified in
+            a single call.
+
+        :param before: a datetime object, specifying this will list messages prior to this
+        :type before: :class:`datetime.datetime`
+        :param since: a datetime object, specify this to list
+            the *most recent* messages after it
+            (**not** the messages right after the reference message)
+        :type since: :class:`datetime.datetime`
+        :param after: a datetime object, specifying this will
+            return the messages just after the reference message
+        :type after: :class:`datetime.datetime`
+        :param int limit: a limit on the number of messages returned (between
+            1 and 100 inclusive)
+        :rtype: :class:`~groupy.object.listers.MessagePager`
+        :raises ValueError: if more than one of ``before``, ``after`` or
+            ``since`` are specified
+        """
+        # Messages obtained with the 'after' parameter are in reversed order.
+        backward = after is not None
+
+        # Fetch the messages.
+        try:
+            r = endpoint.Gallery.index(self._idkey, before=before, 
+                                        since=since, after=after, limit=limit)
+        except errors.ApiError as e:
+            # NOT_MODIFIED, in this case, means no more messages. Some versions
+            # of the API return the 304 code inside the response envelope, but
+            # sometimes there is no JSON response and it returns the 304 in the
+            # response http code only.
+            try:
+                if e.args[0]['code'] == status.NOT_MODIFIED:
+                    return None
+            except TypeError:
+                if e.args[0].status_code == status.NOT_MODIFIED:
+                    return None
+            raise e
+
+        gallery_messages = (Message(self, **m) for m in r[self._mkey])
+        return GalleryPager(self, gallery_messages)
 
 
 class Group(Recipient):

--- a/groupy/object/responses.py
+++ b/groupy/object/responses.py
@@ -187,6 +187,15 @@ class Group(Recipient):
             self.max_members, self.message_count)
 
     @classmethod
+    def get(cls, group_id):
+        """Get a group by its id
+        :param str group_id: the ID of the group to get.
+        :returns: group object of the group with the given id
+        :rtype: :class: `~groupy.object.responses.Group`
+        """
+        return cls(**endpoint.Groups.show(group_id))
+
+    @classmethod
     def list(cls, former=False):
         """List all of your current or former groups.
 


### PR DESCRIPTION
The Gallery is a relatively recent addition (~12-18 months ago) to GroupMe. It is useful to find media from the group quickly. 

The Gallery endpoint is not officially supported within their API docs, but adding support within the library won't regress any other functionality and is a useful addition. 

In addition, I added the ability to get a single group by ID. I know this is possible to do with the FilterList, but that still requires a call that returns the entire list of groups, rather than just one. This is a common task and a more efficient method for it seems useful. 
