### PR TITLE
Fix Direct Messages unable to load

### DIFF
--- a/groupy/api/messages.py
+++ b/groupy/api/messages.py
@@ -124,8 +124,8 @@ class Message(GenericMessage):
 class DirectMessage(GenericMessage):
     # manager could be from a chat or from a group... is that a problem?
     def __init__(self, manager, **data):
-        conversation_id = self.__class__.get_conversation_id(data)
-        super().__init__(manager, conversation_id, **data)
+        data['conversation_id'] = self.__class__.get_conversation_id(data)
+        super().__init__(manager, **data)
 
     @staticmethod
     def get_conversation_id(data):


### PR DESCRIPTION
On this line 127, `conversation_id` is created from the data given. However, `data` is also expanded into the `super().__init__` on the following line, raising the exception `"TypeError: __init__() got multiple values for argument 'conversation_id'"`. 

I'm not entirely sure of what the `join` in `get_conversation_id` does, but my suggested solution is to simply set `data['conversation_id']` equal to the returned value from `get_conversation_id`, and then pass only `data` into `super().__init__`.