### PR TITLE
better handle unexpected datetimes

### DIFF
--- a/groupy/api/messages.py
+++ b/groupy/api/messages.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from . import base
 from .attachments import Attachment
@@ -261,10 +261,9 @@ class GenericMessage(base.ManagedResource):
         try:
 
             self.created_at = datetime.fromtimestamp(self.created_at)
-        except:
-            print('failure creating date for {}'.format(self.created_at))
-            print(data)
-            raise
+        except OverflowError:
+            # for very strange/wrong dates: https://stackoverflow.com/a/36180569/8207
+            self.created_at = datetime(1970, 1, 1) + timedelta(seconds=self.created_at)
         attachments = self.data.get('attachments') or []
         self.attachments = Attachment.from_bulk_data(attachments)
         self._likes = Likes(self.manager.session, self.conversation_id,

--- a/groupy/api/messages.py
+++ b/groupy/api/messages.py
@@ -258,7 +258,13 @@ class GenericMessage(base.ManagedResource):
     def __init__(self, manager, conversation_id, **data):
         super().__init__(manager, **data)
         self.conversation_id = conversation_id
-        self.created_at = datetime.fromtimestamp(self.created_at)
+        try:
+
+            self.created_at = datetime.fromtimestamp(self.created_at)
+        except:
+            print('failure creating date for {}'.format(self.created_at))
+            print(data)
+            raise
         attachments = self.data.get('attachments') or []
         self.attachments = Attachment.from_bulk_data(attachments)
         self._likes = Likes(self.manager.session, self.conversation_id,

--- a/groupy/api/messages.py
+++ b/groupy/api/messages.py
@@ -259,7 +259,6 @@ class GenericMessage(base.ManagedResource):
         super().__init__(manager, **data)
         self.conversation_id = conversation_id
         try:
-
             self.created_at = datetime.fromtimestamp(self.created_at)
         except OverflowError:
             # for very strange/wrong dates: https://stackoverflow.com/a/36180569/8207


### PR DESCRIPTION
@rhgrant10 ran into this error importing data from a (very old) group. 

fixes a an error: `OverflowError: timestamp out of range for platform time_t` if the message's `created_at` is `-62135596800` on certain OS's (which I've seen in the wild).

0.8.0 otherwise seems to be working great! thanks for the update.