### PR TITLE
Fix pickling/unpickling of Resource objects

### DIFF
--- a/groupy/api/base.py
+++ b/groupy/api/base.py
@@ -28,6 +28,12 @@ class Resource:
                                                       attr))
         return self.data[attr]
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+
 
 class ManagedResource(Resource):
     """Class to represent an API object."""


### PR DESCRIPTION
Add \_\_getstate\_\_ and \_\_setstate\_\_ methods to the Resource class to avoid hitting the recursion limit when trying to pickle/unpickle Resource objects.

A similar issue/solution can be found [here](https://stackoverflow.com/a/12102691)