### PR TITLE
 Fix Image attachment creation

### DIFF
--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -85,7 +85,7 @@ To avoid this, use the ``omit`` parameter to specify fields to omit.
     >>> groups = client.groups.list(omit="memberships")
 
 .. note::
-    
+
     Multiple fields must be formatted in a CSV (e.g. "memberships,description").
     At the time of this writing, however, the API only supports omission of
     "memberships."
@@ -177,7 +177,7 @@ Listing messages from a group
     >>> message_page = group.messages.list()
     >>> for message in group.messages.list_all():
     ...     print(message.text)
-    ... 
+    ...
     >>> message_page = group.messages.list_after(message_id=message)
 
 .. note:: See "Listing messages" for details.
@@ -250,7 +250,7 @@ Removing members from groups
 
 .. note::
 
-    Remember, members are specific to the group from which they are 
+    Remember, members are specific to the group from which they are
     obtained.
 
 .. code-block:: python
@@ -327,7 +327,7 @@ you can obtain the actual image. To create a new image from a local file object,
 .. code-block:: python
 
     >>> with open('some-image', 'rb') as f:
-    >>>     image = attachments.Image.from_file(f)    
+    >>>     image = client.images.from_file(f)
 
 To fetch the actual image bytes of an image attachment, use the ``client``:
 
@@ -365,7 +365,7 @@ saw you with @Zoe Childs at the park!'"
 
     >>> mentions = attachments.Mentions(loci=[[0, 5], [25, 11]],
     ...                                 user_ids=['2345', '6789'])
-    
+
 
 
 Emojis

--- a/groupy/api/attachments.py
+++ b/groupy/api/attachments.py
@@ -134,7 +134,7 @@ class Images(base.Manager):
         :rtype: :class:`~groupy.api.attachments.Image`
         """
         image_urls = self.upload(fp)
-        return Image(self, image_urls['url'])
+        return Image(image_urls['url'], source_url=image_urls['picture_url'])
 
     def upload(self, fp):
         """Upload image data to the image service.
@@ -147,8 +147,8 @@ class Images(base.Manager):
         :rtype: dict
         """
         url = utils.urljoin(self.url, 'pictures')
-        response = self.session.post(url, files={'file': fp})
-        image_urls = response.data['payload']
+        response = self.session.post(url, data=fp.read())
+        image_urls = response.data
         return image_urls
 
     def download(self, image, url_field='url', suffix=None):

--- a/groupy/session.py
+++ b/groupy/session.py
@@ -50,7 +50,10 @@ class Response:
         except ValueError as e:
             raise exceptions.InvalidJsonError(self._resp) from e
         except KeyError as e:
-            raise exceptions.MissingResponseError(self._resp) from e
+            try:
+                return self.json()['payload']
+            except KeyError:
+                raise exceptions.MissingResponseError(self._resp) from e
 
     @property
     def errors(self):

--- a/tests/api/test_images.py
+++ b/tests/api/test_images.py
@@ -1,3 +1,4 @@
+import io
 import unittest
 from unittest import mock
 
@@ -13,11 +14,11 @@ class ImagesTests(unittest.TestCase):
 class UploadImageTests(ImagesTests):
     def setUp(self):
         super().setUp()
-        self.m_session.post.return_value = mock.Mock(data={'payload': 'bar'})
-        self.result = self.images.upload('foo')
+        self.m_session.post.return_value = mock.Mock(data={'url': 'bar'})
+        self.result = self.images.upload(io.BytesIO(b'foo'))
 
     def test_result_is_payload(self):
-        self.assertEqual(self.result, 'bar')
+        self.assertEqual(self.result, {'url': 'bar'})
 
 
 class DownloadImageTests(ImagesTests):


### PR DESCRIPTION
Send the binary image data using the data parameter in the request rather than the file parameter. Sending the data as a file produced a 500 internal server error.

The instructions on how to create an image attachment have also been updated to reflect the most recent version of Groupy.