### PR TITLE
make all inputs to mentions optional

### DIFF
--- a/groupy/api/attachments.py
+++ b/groupy/api/attachments.py
@@ -100,7 +100,9 @@ class Mentions(Attachment):
     :type user_ids: :class:`list`
     """
 
-    def __init__(self, loci, user_ids):
+    def __init__(self, loci=None, user_ids=None):
+        loci = loci or []
+        user_ids = user_ids or []
         super().__init__(type='mentions', loci=loci, user_ids=user_ids)
 
 


### PR DESCRIPTION
Am not so sure what exactly causes this error, but was getting it occasionally importing some very old data. Sometimes there are attachments tagged as mentions but without any metadata

```
  File "/home/importer.py", line 86, in load_messages
    for message in messages.autopage():
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/pagers.py", line 61, in autopage
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/pagers.py", line 133, in fetch_next
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/pagers.py", line 51, in fetch_next
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/pagers.py", line 42, in fetch
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/messages.py", line 27, in _raw_list
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/messages.py", line 27, in <listcomp>
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/messages.py", line 294, in __init__
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/messages.py", line 268, in __init__
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/attachments.py", line 55, in from_bulk_data
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/attachments.py", line 55, in <listcomp>
  File "/lib/python3.5/site-packages/GroupyAPI-0.8.0-py3.5.egg/groupy/api/attachments.py", line 44, in from_data
TypeError: __init__() missing 1 required positional argument: 'loci'
```