### PR TITLE
Changed default for dm_notification and callback_url to False instead…

### DIFF
--- a/groupy/api/bots.py
+++ b/groupy/api/bots.py
@@ -17,8 +17,8 @@ class Bots(base.Manager):
         response = self.session.get(self.url)
         return [Bot(self, **bot) for bot in response.data]
 
-    def create(self, name, group_id, avatar_url=None, callback_url=None,
-               dm_notification=None, **kwargs):
+    def create(self, name, group_id, avatar_url=None, callback_url=False,
+               dm_notification=False, **kwargs):
         """Create a new bot in a particular group.
 
         :param str name: bot name


### PR DESCRIPTION
To fix the issue I opened here:
https://github.com/rhgrant10/Groupy/issues/61

Summary:
The Groupy-API module passes None by default for the dm_notification parameter, but GroupMe strictly expects a boolean. Instead of throwing an error, GroupMe silently accepts the invalid None value and provisions a completely unresponsive bot. Changing the module's default to False forces it to pass a valid boolean, preventing the backend glitch and restoring proper webhook functionality.